### PR TITLE
通用化不支持监听本机时关闭接收缓冲的情况

### DIFF
--- a/local/ProxyHandler.py
+++ b/local/ProxyHandler.py
@@ -153,8 +153,10 @@ class AutoProxyHandler(BaseHTTPRequestHandler):
             client_ip = self.client_address[0]
             if client_ip.endswith('127.0.0.1') or client_ip == '::1':
                 self.disable_nagle_algorithm = True
-                if sys.platform != 'darwin':
+                try:
                     self.request.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 0)
+                except OSError:
+                    pass #并非所有系统都支持关闭接收缓冲
         BaseHTTPRequestHandler.setup(self)
 
     def write(self, d, logerror=None):


### PR DESCRIPTION
在FreeBSD上运行报错同 #45 ，因而我认为这里用一个异常捕获通用一点。

这样改动过后本程序在FreeBSD上就可以正常运行了。

Signed-off-by: Hollow Man <hollowman@hollowman.ml>