### PR TITLE
Do not use CFW or GAE when it is not set.

### DIFF
--- a/local/ProxyHandler.py
+++ b/local/ProxyHandler.py
@@ -1400,6 +1400,10 @@ class AutoProxyHandler(BaseHTTPRequestHandler):
     def go_TEMPACT(self):
         if GC.LISTEN_ACT == 'GAE' and self.command not in self.gae_fetcmds:
             return self.go_BAD()
+        if GC.LISTEN_ACT == 'GAE' and not GC.GAE_APPIDS:
+            return self.go_BAD()
+        if GC.LISTEN_ACT == "CFW" and not (GC.CFW_SUBDOMAIN and GC.CFW_WORKERS or GC.CFW_WORKER):
+            return self.go_BAD()
         self._set_temp_ACT()
         self.action = GC.LISTEN_ACTNAME
         self.do_action()


### PR DESCRIPTION
Sometimes FAKESNI rules don't work by accident, such as when visiting [Discord](https://discord.com/).

When this happens, GotoX should not add the user to CFW or GAE rules if they are not set, otherwise the user will not be able to access the site.

English is not my mother tongue, please forgive me if there are any grammatical mistakes.