### PR TITLE
扩大响应头数量限制

### DIFF
--- a/local/HTTPUtil.py
+++ b/local/HTTPUtil.py
@@ -14,7 +14,7 @@ import threading
 from time import mtime, sleep
 from queue import Queue
 from threading import _start_new_thread as start_new_thread
-from http.client import HTTPResponse
+from http.client import HTTPResponse, _MAXHEADERS
 from .GlobalConfig import GC
 from .compat.openssl import (
     zero_errno, zero_EOF_error, res_ciphers, SSL, SSLConnection,
@@ -231,6 +231,8 @@ N3Tphr+AwTioLnSvaNDyqo+zfpJeXsoiwFLH+Y6YsP6R5IjVBzUoimFgeWeTSbYP
 YQIDAQAB
 -----END PUBLIC KEY-----
 '''}
+
+_MAXHEADERS = 1024
 
 gws_servername = GC.GAE_SERVERNAME
 gae_testgwsiplist = GC.GAE_TESTGWSIPLIST


### PR DESCRIPTION
有时，如访问Outlook的时候，由于同时设置过多的cookie，会导致响应头数量超过默认的100个的限制，这个PR将该限制上调到了1024个。